### PR TITLE
Fix for search filter (rock types, metamorphic grades, minerals[?]) issues

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,7 +14,7 @@ from flask import (
     session
 )
 from flask_mail import Mail, Message
-from utilities import paginate_model
+from utilities import paginate_model, multi_args_to_list
 
 mail = Mail()
 metpet_ui = Flask(__name__)
@@ -38,7 +38,8 @@ def search():
     #get all filter options from API, use format = json and minimum page sizes to speed it up
     if request.args.get("resource") == "samples":
         #resource value set in search_form.html, appends samples.html to bottom of page
-        return redirect(url_for("samples")+"?"+urlencode(request.args))
+        fixedListArgs = multi_args_to_list(request.args.iteritems(multi=True))
+        return redirect(url_for("samples")+"?"+urlencode(fixedListArgs))
 
     if request.args.get("resource") == "chemical_analyses":
         #minerals_and option not valid parameter for analyses
@@ -83,7 +84,8 @@ def search_chemistry():
         return redirect(url_for("chemical_analyses")+"?"+urlencode(request.args))
 
     if request.args.get("resource") == "sample":
-        return redirect(url_for("samples")+"?"+urlencode(request.args)+"&chemical_analyses_filters=True")
+        fixedListArgs = multi_args_to_list(request.args.iteritems(multi=True))
+        return redirect(url_for("samples")+"?"+urlencode(fixedListArgs)+"&chemical_analyses_filters=True")
 
     oxides = get(env("API_HOST")+"oxides/", params = {"fields": "species", "page_size": 100, "format": "json"}).json()["results"]
     elements = get(env("API_HOST")+"elements/", params = {"fields": "name,symbol", "page_size": 120, "format": "json"}).json()["results"]

--- a/app.py
+++ b/app.py
@@ -14,7 +14,7 @@ from flask import (
     session
 )
 from flask_mail import Mail, Message
-from utilities import paginate_model, multi_args_to_list
+from utilities import paginate_model, combine_identical_parameters
 
 mail = Mail()
 metpet_ui = Flask(__name__)
@@ -38,7 +38,7 @@ def search():
     #get all filter options from API, use format = json and minimum page sizes to speed it up
     if request.args.get("resource") == "samples":
         #resource value set in search_form.html, appends samples.html to bottom of page
-        fixedListArgs = multi_args_to_list(request.args.iteritems(multi=True))
+        fixedListArgs = combine_identical_parameters(request.args.iteritems(multi=True))
         return redirect(url_for("samples")+"?"+urlencode(fixedListArgs))
 
     if request.args.get("resource") == "chemical_analyses":
@@ -84,7 +84,7 @@ def search_chemistry():
         return redirect(url_for("chemical_analyses")+"?"+urlencode(request.args))
 
     if request.args.get("resource") == "sample":
-        fixedListArgs = multi_args_to_list(request.args.iteritems(multi=True))
+        fixedListArgs = combine_identical_parameters(request.args.iteritems(multi=True))
         return redirect(url_for("samples")+"?"+urlencode(fixedListArgs)+"&chemical_analyses_filters=True")
 
     oxides = get(env("API_HOST")+"oxides/", params = {"fields": "species", "page_size": 100, "format": "json"}).json()["results"]

--- a/utilities.py
+++ b/utilities.py
@@ -28,7 +28,7 @@ def paginate_model(model_name, data, filters):
 def multi_args_to_list(argsIn):
     argsOut = {}
     for arg in argsIn:
-        if arg[0] == 'rock_types' or arg[0] == 'metamorphic_grades':
+        if arg[0] == 'rock_types' or arg[0] == 'metamorphic_grades' or arg[0] == 'minerals':
             if arg[0] in argsOut:
                 argsOut[arg[0]] += ',' + arg[1]
             else:

--- a/utilities.py
+++ b/utilities.py
@@ -20,3 +20,19 @@ def paginate_model(model_name, data, filters):
     last = url_for(model_name)+'?page='+str(count/size+1)+'&'+urlencode(filters)
 
     return (next, previous, last, count)
+
+# When multiple filters are passed to a search request, each filter option is encoded
+#   as a separate paramater, e.g. 'rock_types=Gneiss&rock_types=Slate'.  The API
+#   doesn't like this, instead preferring comma-separated values in one string.  This
+#   fixes that.
+def multi_args_to_list(argsIn):
+    argsOut = {}
+    for arg in argsIn:
+        if arg[0] == 'rock_types':
+            if arg[0] in argsOut:
+                argsOut[arg[0]] += ',' + arg[1]
+            else:
+                argsOut[arg[0]] = arg[1]
+    else:
+        argsOut[arg[0]] = arg[1]
+    return argsOut

--- a/utilities.py
+++ b/utilities.py
@@ -21,18 +21,14 @@ def paginate_model(model_name, data, filters):
 
     return (next, previous, last, count)
 
-# When multiple filters are passed to a search request, each filter option is encoded
-#   as a separate paramater, e.g. 'rock_types=Gneiss&rock_types=Slate'.  The API
-#   doesn't like this, instead preferring comma-separated values in one string.  This
-#   fixes that.
-def multi_args_to_list(argsIn):
-    argsOut = {}
-    for arg in argsIn:
-        if arg[0] == 'rock_types' or arg[0] == 'metamorphic_grades' or arg[0] == 'minerals':
-            if arg[0] in argsOut:
-                argsOut[arg[0]] += ',' + arg[1]
+def combine_identical_parameters(paramsIn):
+    paramsOut = {}
+    for param in paramsIn:
+        if param[0] == 'rock_types' or param[0] == 'metamorphic_grades' or param[0] == 'minerals':
+            if param[0] in paramsOut:
+                paramsOut[param[0]] += ',' + param[1]
             else:
-                argsOut[arg[0]] = arg[1]
+                paramsOut[param[0]] = param[1]
         else:
-            argsOut[arg[0]] = arg[1]
-    return argsOut
+            paramsOut[param[0]] = param[1]
+    return paramsOut

--- a/utilities.py
+++ b/utilities.py
@@ -28,11 +28,11 @@ def paginate_model(model_name, data, filters):
 def multi_args_to_list(argsIn):
     argsOut = {}
     for arg in argsIn:
-        if arg[0] == 'rock_types':
+        if arg[0] == 'rock_types' or arg[0] == 'metamorphic_grades':
             if arg[0] in argsOut:
                 argsOut[arg[0]] += ',' + arg[1]
             else:
                 argsOut[arg[0]] = arg[1]
-    else:
-        argsOut[arg[0]] = arg[1]
+        else:
+            argsOut[arg[0]] = arg[1]
     return argsOut


### PR DESCRIPTION
The interface was passing multiple search parameters of a single type (e.g. Slate and Gneiss rock types) as multiple keyvalue pairs in the request (e.g. "rock_types=Slate&rock_types=Gneiss").  The API doesn't like this, instead preferring a single string with comma-separated values (e.g. "rock_types=Slate,Gneiss").  PR adds a function in utilities.py to fix this and implements it for samples search.

Fix should work for minerals in the OR case, but since numbers of search results still aren't adding up, more API investigation is required.