### PR TITLE
Fix for apache issuing 500 errors (generating wrong config file path)

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ metpet_ui = Flask(__name__)
 metpet_ui.config.from_object("config")
 mail.init_app(metpet_ui)
 
-dotenv.read_dotenv(os.path.dirname(__file__) + '../app_variables.env')
+dotenv.read_dotenv(os.path.dirname(__file__) + '/../app_variables.env')
 
 
 @metpet_ui.route("/")


### PR DESCRIPTION
I believe Python and Apache are generating two different paths, one with a trailing slash and one without.  This was causing no issue on local machines (where the interface was run through Python) but was causing 500 internal errors on the production server where Apache is serving the interface.  Adding a leading slash to the hard-coded portion of the config filepath fixes this.  (Already tested in production, hotfix)